### PR TITLE
Add entries for 'awesome_albert_plugins' plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Awesome Albert [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
-===============
+# Awesome Albert [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
 A curated list of third party albert extensions. Please note that there are also a lot of [official extensions](https://github.com/albertlauncher/python) shipped with the app. Also check [this search](https://github.com/search?q=albert+__title__+__version__+handleQuery+language%3APython&type=code) for all albert extensions on GitHub.
 
 ## List of content
@@ -16,19 +16,45 @@ A curated list of third party albert extensions. Please note that there are also
 - [IPv4/IPv6 Subnet Calculator](https://github.com/Bierchermuesli/albert-subnetcalc)
 - [MAC addr](https://github.com/Bierchermuesli/albert-macaddr) Adress re-formating & HW Vendor Lookup (Local Cache or API)
 - [Remmina connections](https://github.com/KuenzelIT/albert-python-remmina)
+- [Remmina (awesome_albert_plugins)](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/remmina) - 🖥️ Start a [Remmina](https://remmina.org/) VNC/SFTP connection
 
 ## Productivity
 
 - [Password generator](https://github.com/baltpeter/albert-extensions/blob/master/pwgen.py)
 - [Hunspell spell checking](https://github.com/AlbertExtensions/spell)
 - [Google Translate](https://github.com/dshoreman/albert-translate) with API key, many options
+- [Google Translate
+  (awesome_albert_plugins)](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/google_translate) - 🉑 Reimplementation of [this](https://github.com/dshoreman/albert-translate) plugin with persistent storage of previous searches, no need for API key and smart HTTP querying to avoid blocking from Google.
 - [Deepl Translate](https://github.com/lilianmallardeau/deepl-plugin-albert/) with API key
+- [Anki](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/anki) - 📇 Generate flashcards for [Anki](https://apps.ankiweb.net/)
+- [Clock](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/clock) - ⏰ Create countdown and stopwatch timers
+- [Colors](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/colors) - 🎨 Color lookup using RGB, hex notation or color name
+- [Emoji](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/emoji) - 🎉 Search for and copy emojis to clipboard
+- [Errno](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/errno_lookup) - ❗Lookup and get information on Linux error codes
+- [Image Search](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/image_search) - 📷 Search the web for images, download them and/or copy them to clipboard
+- [Jira](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/jira) - 📝 View and edit your [Jira](https://www.atlassian.com/software/jira) tickets from Albert
+- [Meme_generator](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/meme_generator) - Generate memes and copy them to clipboard
+- [Pass_rlded](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/pass_rlded) - 🔒 UNIX Password Manager interaction with fuzzy-search capabilities
+- [Pass TOTP](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/pass_totp_cli) - 🔢 Generate 2FA codes with [Pass](https://www.passwordstore.org/) and [totp](https://pypi.org/project/totp/)
+- [Saxophone](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/saxophone) - 🎷 Play your favorite internet radio stations / streams
+- [Scratchpad](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/scratchpad) - 📝 Take quick notes into a single textfile
+- [Taskwarrior](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/taskwarrior) - 🪖 Interact with the [Taskwarrior](https://taskwarrior.org/) task manager
+- [Timezones](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/timezones) - 🌏 Lookup timezone information
+- [Tldr Lookup](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/tldr_pages) - Lookup [tldr](https://github.com/tldr-pages/tldr) pages and commands
+- [URL Error Lookup](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/url_lookup) - 🔗 Lookup URL error codes
+- [Words](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/words) - 🔤 Lookup a word definition, synonyms and antonyms
+- [Xkcd](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/xkcd) - 📓 List and fuzzy-search the latest [xkcd](https://fr.wikipedia.org/wiki/Xkcd) comics
+- [Template Albert Plugin](https://github.com/bergercookie/awesome-albert-plugins) - 🛠️ Template [cookiecutter](https://github.com/cookiecutter/cookiecutter) for creating new Albert plugins
 
 ## System
 
 - [KDE Services](https://github.com/ManuelArto/KDEServices-AlbertExtension)
 - [Flameshot screenshots](https://github.com/baltpeter/albert-extensions/blob/master/flameshot.py)
 - [Open a volatile FireFox session](https://github.com/baltpeter/albert-extensions/blob/master/fx.py)
+- [Bluetooth](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/bluetooth) - 🦷 Enable/disable bluetooth functionality
+- [Pulse Control](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/pulse_control) - 🎤 Enable/disable sources and sinks from Pulse Control
+- [IP show](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/ipshow) - 🌐 Display information about your network interfaces and public IPs
+- [Killproc](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/killproc) - ☠️ Kill processes based on fuzzy-search
 
 ## Web services
 
@@ -39,4 +65,6 @@ A curated list of third party albert extensions. Please note that there are also
 - [stackoverflow.com - Browse articles](https://github.com/AlbertExtensions/Stackoverflow)
 - [openweathermap.org - Forecast](https://github.com/AlbertExtensions/Forecast)
 - [github.com - Starred projects shortcuts](https://github.com/AlbertExtensions/Github-Jump)
-
+- [Harakiri](https://github.com/bergercookie/awesome-albert-plugins/tree/master/plugins/harakiri) - 📫 Create temporary email addresses at [harakirimail.com](https://harakirimail.com/)
+- [`googler`-based autocompletion search](https://github.com/bergercookie/awesome-albert-plugins#googler-based-plugins) - 🔎 for searching on google.com, github.com,
+  stackoverflow, amazon, and a variety of other websites using [googler](https://github.com/jarun/googler)


### PR DESCRIPTION
Adding links to plugins from [https://github.com/bergercookie/awesome-albert-plugins](https://github.com/bergercookie/awesome-albert-plugins) repo as discussed in the Telegram chat.

cc: @ManuelSchneid3r

Here's the rendered result: https://github.com/bergercookie/awesome-albert/blob/main/README.md